### PR TITLE
Expose focal point as center of rotation option

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "source": "src/index.js",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@kitware/vtk.js": "18.2.0"
+    "@kitware/vtk.js": "18.3.0"
   },
   "scripts": {
     "prebuild": "npm run fix",

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -69,6 +69,7 @@ function assignManipulators(style, settings, view) {
         dragEnabled,
         useWorldUpVec,
         worldUpVec,
+        useFocalPointAsCenterOfRotation,
       } = item;
       const manipulator = klass.newInstance();
       manipulator.setButton(button);
@@ -90,6 +91,11 @@ function assignManipulators(style, settings, view) {
       }
       if (worldUpVec !== undefined) {
         manipulator.setWorldUpVec(worldUpVec);
+      }
+      if (useFocalPointAsCenterOfRotation !== undefined) {
+        manipulator.setUseFocalPointAsCenterOfRotation(
+          useFocalPointAsCenterOfRotation
+        );
       }
     }
   });


### PR DESCRIPTION
Allows to set the focal point as center of rotation option for the rotate manipulator in the interactorSettings object.