### PR TITLE
allow broader range of vtk.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "source": "src/index.js",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@kitware/vtk.js": "18.3.0"
+    "@kitware/vtk.js": "^18.3.0"
   },
   "scripts": {
     "prebuild": "npm run fix",


### PR DESCRIPTION
Is there any reason why the vtk.js version is fixed to a single release? Could this library specify a range to make it easier to use it with other vtk.js logic?

This seems to fix #15