### PR TITLE
fix(ShareDataSet): Stop data listener on unmount

### DIFF
--- a/src/core/ShareDataSet.js
+++ b/src/core/ShareDataSet.js
@@ -46,6 +46,13 @@ export default class ShareDataSet extends Component {
     return trivialProducer;
   }
 
+  componentWillUnmount() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+  }
+
   render() {
     this.update();
     return (


### PR DESCRIPTION
The trivial producer listener should be removed when the component is unmounted.

@WillCMcC @agirault