### PR TITLE
fix(Reader): Add options property to Reader

### DIFF
--- a/src/core/Reader.js
+++ b/src/core/Reader.js
@@ -33,8 +33,7 @@ export default class Reader extends Component {
                 <DownstreamContext.Consumer>
                   {(downstream) => {
                     if (!this.reader) {
-                      const { vtkClass } = this.props;
-                      this.reader = vtk({ vtkClass });
+                      this.reader = this.createReader(this.props);
                     }
                     if (!this.downstream) {
                       downstream.setInputConnection(
@@ -74,11 +73,19 @@ export default class Reader extends Component {
     this.reader = null;
   }
 
+  createReader(props) {
+    const { vtkClass, options } = props;
+    return vtk({
+      vtkClass,
+      progressCallback: options.progressCallback,
+    });
+  }
+
   update(props, previous) {
     const { vtkClass, url, parseAsText, parseAsArrayBuffer, options } = props;
 
     if (vtkClass && (!previous || vtkClass !== previous.vtkClass)) {
-      this.reader = vtk({ vtkClass });
+      this.reader = this.createReader(props);
       this.downstream.setInputConnection(
         this.reader.getOutputPort(),
         this.props.port

--- a/src/core/Reader.js
+++ b/src/core/Reader.js
@@ -75,7 +75,7 @@ export default class Reader extends Component {
   }
 
   update(props, previous) {
-    const { vtkClass, url, parseAsText, parseAsArrayBuffer } = props;
+    const { vtkClass, url, parseAsText, parseAsArrayBuffer, options } = props;
 
     if (vtkClass && (!previous || vtkClass !== previous.vtkClass)) {
       this.reader = vtk({ vtkClass });
@@ -86,7 +86,7 @@ export default class Reader extends Component {
     }
 
     if (url && (!previous || url !== previous.url)) {
-      this.reader.setUrl(url).then(() => {
+      this.reader.setUrl(url, options).then(() => {
         if (!this.reader) {
           return;
         }
@@ -137,6 +137,7 @@ Reader.defaultProps = {
   vtkClass: '',
   renderOnUpdate: true,
   resetCameraOnUpdate: true,
+  options: { binary: true },
 };
 
 Reader.propTypes = {
@@ -179,6 +180,11 @@ Reader.propTypes = {
    * Automatically reset camera on data loaded
    */
   resetCameraOnUpdate: PropTypes.bool,
+
+  /**
+   * Reader options
+   */
+  options: PropTypes.object,
 
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),


### PR DESCRIPTION
Add `options` property to the Reader, which will be passed to STLReader(or other vtk.js readers). The main reason is to be able to pass `progressCallback` and display progress in UI.

~However there is also bug related to progressCallback on vtk.js side. I submitted [PR with fix](https://github.com/Kitware/vtk-js/pull/2007), so if you want to check scenario with progressCallback - it will not work until aforementioned PR merged.~
The second commit make it work without the changes to the vtk.js reader.