### PR TITLE
fix: mark vtk.js as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "module": "dist/esm/index.js",
   "source": "src/index.js",
   "dependencies": {
-    "@babel/runtime": "^7.12.5",
-    "@kitware/vtk.js": "^18.7.0"
+    "@babel/runtime": "^7.12.5"
   },
   "scripts": {
     "prebuild": "npm run fix",
@@ -28,7 +27,8 @@
     "semantic-release": "semantic-release"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0",
+    "@kitware/vtk.js": "^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
Having vtk.js as a dependency makes it extremely difficult to avoid double versions of the same library if vtk.js is also listed as dependency of the project itself.

Just like it happens with React, I think vtk.js should be a peerDependency so that the consumers can better control it.

Keep it mind 99% of the users using this library are likely going to also import from vtk.js directly to access utility modules and such, so they will need to add a vtk.js version to their package.json too.