### PR TITLE
fix(View): don’t throw `cannot get getViewMatrix of undefined` error when showCubeAxes is set to false

### DIFF
--- a/src/core/View.js
+++ b/src/core/View.js
@@ -166,6 +166,10 @@ export default class View extends Component {
     this.resetCamera = this.resetCamera.bind(this);
     const bbox = vtkBoundingBox.newInstance({ bounds: [0, 0, 0, 0, 0, 0] });
     this.updateCubeBounds = () => {
+      if (!this.props.showCubeAxes) {
+        return;
+      }
+
       bbox.reset();
       const { props } = this.renderer.get('props');
       for (let i = 0; i < props.length; i++) {
@@ -556,8 +560,8 @@ export default class View extends Component {
         const representationIds = [];
         this.selections.forEach((v) => {
           const { prop } = v.getProperties();
-          const representationId =
-            prop?.get('representationId').representationId;
+          const representationId = prop?.get('representationId')
+            .representationId;
           if (representationId) {
             representationIds.push(representationId);
           }


### PR DESCRIPTION
When we switch between different mouse adaptors programmatically (directly interacting with the `style` and `view` instances) we often get the error:

```
cannot get getViewMatrix of undefined
```

This happens on the CubeAxesActor instance, and only happens if `showCubeAxes` prop is not set to `true`.

This change prevents the error from happening.