### PR TITLE
fix(rollup): Do not bundle vtk.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,10 @@ export default {
         format: 'cjs',
       },
     ],
-    external: ['react', 'prop-types'],
+    external: (id) => (
+      ['react', 'prop-types'].indexOf(id) > 0 ||
+      /^@kitware\/vtk\.js/.test(id)
+    ),
     plugins: [
       nodeResolve({
         // include: 'node_modules/**',


### PR DESCRIPTION
In reference to #28, we should not bundle `@kitware/vtk.js`. Additionally, this directly impacts `vtkMapper`, as setting global/static coincident topology parameters is done at a module level, and bundling vtk.js with react-vtk-js means it's impossible to set global parameters for react-vtk-js.

This will mean all consumers must install `@kitware/vtk.js` alongside react-vtk-js. Should this be a breaking change, or are we okay having people realize this once npm/yarn complains about missing peer deps?