### PR TITLE
(Fix) Change falsy checks on slice value to nullish checks

### DIFF
--- a/src/core/SliceRepresentation.js
+++ b/src/core/SliceRepresentation.js
@@ -139,23 +139,23 @@ export default class SliceRepresentation extends Component {
     }
 
     // ijk
-    if (iSlice && (!previous || iSlice !== previous.iSlice)) {
+    if (iSlice != null && (!previous || iSlice !== previous.iSlice)) {
       this.mapper.setISlice(iSlice);
     }
-    if (jSlice && (!previous || jSlice !== previous.jSlice)) {
+    if (jSlice != null && (!previous || jSlice !== previous.jSlice)) {
       this.mapper.setJSlice(jSlice);
     }
-    if (kSlice && (!previous || kSlice !== previous.kSlice)) {
+    if (kSlice != null && (!previous || kSlice !== previous.kSlice)) {
       this.mapper.setKSlice(kSlice);
     }
     // xyz
-    if (xSlice && (!previous || xSlice !== previous.xSlice)) {
+    if (xSlice != null && (!previous || xSlice !== previous.xSlice)) {
       this.mapper.setXSlice(xSlice);
     }
-    if (ySlice && (!previous || ySlice !== previous.ySlice)) {
+    if (ySlice != null && (!previous || ySlice !== previous.ySlice)) {
       this.mapper.setYSlice(ySlice);
     }
-    if (zSlice && (!previous || zSlice !== previous.zSlice)) {
+    if (zSlice != null && (!previous || zSlice !== previous.zSlice)) {
       this.mapper.setZSlice(zSlice);
     }
 


### PR DESCRIPTION
There was an issue in SliceRepresenation.js: when providing 0 for i,j,k,x,y, or z slice, a falsy check would prevent the mapper from updating the corresponding slice. I've updating to a nullish check with `!=` because that is the convention I am used to but can update if need be!