### PR TITLE
docs: fix publish to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,10 +22,11 @@ jobs:
       - name: Build
         run: npm run build
       - name: Publish docs
-        if: github.ref == 'refs/heads/master'
-        env:
-          GIT_PUBLISH_URL: https://${{ secrets.GH_PUBLISH_CREDS }}@github.com/Kitware/react-vtk-js.git
-        run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "sebastien.jourdain@kitware.com"
-          npm run deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./usage/dist
+          user_name: 'Github Actions'
+          user_email: 'sebastien.jourdain@kitware.com'
+          commit_message: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Publishing to docs seems to be [failing](https://github.com/Kitware/react-vtk-js/runs/5452561422?check_suite_focus=true), seems like last push to `gh-pages` branch was ~10 months so maybe the creds were changed.

This PR changes current workflow to publish usage docs from using `gh-pages` command line to use [github-pages-action](https://github.com/marketplace/actions/github-pages-action) action. 

This uses `GITHUB_TOKEN` provided by all github actions instead of custom auth.

Note: Haven't tested if it works, and not sure if instructions [here](https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-first-deployment-with-github_token) would need to be followed.