### PR TITLE
fix(View): revert mousedown capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@babel/plugin-transform-runtime": "^7.12.10",
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
-        "@kitware/vtk.js": "^24.7.1",
+        "@kitware/vtk.js": "^24.17.0",
         "@rollup/plugin-babel": "^5.2.2",
         "@rollup/plugin-commonjs": "17.0.0",
         "@rollup/plugin-eslint": "^8.0.1",
@@ -46,7 +46,7 @@
         "semantic-release": "17.3.1"
       },
       "peerDependencies": {
-        "@kitware/vtk.js": "^24.7.1",
+        "@kitware/vtk.js": "^24.17.0",
         "react": "^16.0.0"
       }
     },
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2128,24 +2128,24 @@
       "dev": true
     },
     "node_modules/@kitware/vtk.js": {
-      "version": "24.7.1",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-24.7.1.tgz",
-      "integrity": "sha512-geOFGGpLFertWHu1oo23kScpd4fduBetOWtxFPWf1wlTHw/vxQNnp7+razqBIALOSYjFVftj8zplFAWW58cHhQ==",
+      "version": "24.17.0",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-24.17.0.tgz",
+      "integrity": "sha512-nZC6ktOmxbYG291LvWM7kwwpSEP4kqNstBR347ryrpyBgf8/B7SWqlYlXBeOmxKDw+DEB5wX6BnO6VGHFoFw4A==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "7.16.7",
-        "commander": "8.3.0",
+        "@babel/runtime": "7.17.9",
+        "commander": "9.2.0",
         "d3-scale": "4.0.2",
         "gl-matrix": "3.4.3",
-        "globalthis": "1.0.2",
-        "jszip": "3.7.1",
+        "globalthis": "1.0.3",
+        "jszip": "3.9.1",
         "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
         "spark-md5": "^3.0.2",
         "stream-browserify": "3.0.0",
-        "webworker-promise": "0.4.4",
+        "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
         "xmlbuilder2": "3.0.2"
       },
@@ -4148,12 +4148,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "dev": true,
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/commitizen": {
@@ -6745,9 +6745,9 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
-      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
       "dependencies": {
         "define-properties": "^1.1.3"
@@ -7016,7 +7016,7 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "dev": true
     },
     "node_modules/import-fresh": {
@@ -7752,9 +7752,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.1.tgz",
+      "integrity": "sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==",
       "dev": true,
       "dependencies": {
         "lie": "~3.3.0",
@@ -13465,7 +13465,7 @@
     "node_modules/set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "integrity": "sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -15087,9 +15087,9 @@
       }
     },
     "node_modules/webworker-promise": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/webworker-promise/-/webworker-promise-0.4.4.tgz",
-      "integrity": "sha512-NfdSlaWqd+0iSrQudB0N0MELfJ9TVTlynhXMpi06piuZhyc9Yy7Hz6BFu2HUkvIb9lCS0pFW42ptd/JnXVnptg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webworker-promise/-/webworker-promise-0.5.0.tgz",
+      "integrity": "sha512-14iR79jHAV7ozwvbfif+3wCaApT3I1g8Lo0rJZrwAu6wxZGx/08Y8KXz6as6ZLNUEEufeiEBBYrqyDBClXOsEw==",
       "dev": true
     },
     "node_modules/whatwg-url": {
@@ -16616,9 +16616,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -16905,24 +16905,24 @@
       "dev": true
     },
     "@kitware/vtk.js": {
-      "version": "24.7.1",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-24.7.1.tgz",
-      "integrity": "sha512-geOFGGpLFertWHu1oo23kScpd4fduBetOWtxFPWf1wlTHw/vxQNnp7+razqBIALOSYjFVftj8zplFAWW58cHhQ==",
+      "version": "24.17.0",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-24.17.0.tgz",
+      "integrity": "sha512-nZC6ktOmxbYG291LvWM7kwwpSEP4kqNstBR347ryrpyBgf8/B7SWqlYlXBeOmxKDw+DEB5wX6BnO6VGHFoFw4A==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.16.7",
-        "commander": "8.3.0",
+        "@babel/runtime": "7.17.9",
+        "commander": "9.2.0",
         "d3-scale": "4.0.2",
         "gl-matrix": "3.4.3",
-        "globalthis": "1.0.2",
-        "jszip": "3.7.1",
+        "globalthis": "1.0.3",
+        "jszip": "3.9.1",
         "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
         "spark-md5": "^3.0.2",
         "stream-browserify": "3.0.0",
-        "webworker-promise": "0.4.4",
+        "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
         "xmlbuilder2": "3.0.2"
       }
@@ -18510,9 +18510,9 @@
       "optional": true
     },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "dev": true
     },
     "commitizen": {
@@ -20512,9 +20512,9 @@
       "dev": true
     },
     "globalthis": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
-      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3"
@@ -20710,7 +20710,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "dev": true
     },
     "import-fresh": {
@@ -21257,9 +21257,9 @@
       }
     },
     "jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.1.tgz",
+      "integrity": "sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -25472,7 +25472,7 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "integrity": "sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ==",
       "dev": true
     },
     "set-value": {
@@ -26758,9 +26758,9 @@
       "peer": true
     },
     "webworker-promise": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/webworker-promise/-/webworker-promise-0.4.4.tgz",
-      "integrity": "sha512-NfdSlaWqd+0iSrQudB0N0MELfJ9TVTlynhXMpi06piuZhyc9Yy7Hz6BFu2HUkvIb9lCS0pFW42ptd/JnXVnptg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webworker-promise/-/webworker-promise-0.5.0.tgz",
+      "integrity": "sha512-14iR79jHAV7ozwvbfif+3wCaApT3I1g8Lo0rJZrwAu6wxZGx/08Y8KXz6as6ZLNUEEufeiEBBYrqyDBClXOsEw==",
       "dev": true
     },
     "whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev": "rollup ./src/index.js -c --watch"
   },
   "peerDependencies": {
-    "@kitware/vtk.js": "^24.7.1",
+    "@kitware/vtk.js": "^24.17.0",
     "react": "^16.0.0"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "@babel/plugin-transform-runtime": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
-    "@kitware/vtk.js": "^24.7.1",
+    "@kitware/vtk.js": "^24.17.0",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "17.0.0",
     "@rollup/plugin-eslint": "^8.0.1",

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -375,7 +375,7 @@ export default class View extends Component {
 
     // Assign the mouseDown event, we can't use the React event system
     // because the mouseDown event is swallowed by other logic
-    container.addEventListener('mousedown', this.onMouseDown, true);
+    container.addEventListener('mousedown', this.onMouseDown);
 
     this.update(this.props);
     this.resetCamera();


### PR DESCRIPTION
Reverts setting mousedown on capture. This is related to https://github.com/Kitware/vtk-js/pull/2462 in that preventDefault is no longer invoked by default, so this change (which didn't fix anything anyways) can be reverted.

TODO: update the vtk.js version required, as to avoid mousedown breakage.