### PR TITLE
fix: do not initialize cubeAxesActor if not required

### DIFF
--- a/src/core/View.js
+++ b/src/core/View.js
@@ -311,15 +311,9 @@ export default class View extends Component {
     this.onBoxSelectChange = select;
 
     // Cube Axes
-    this.cubeAxes = vtkCubeAxesActor.newInstance({
-      visibility: false,
-      dataBounds: [-1, 1, -1, 1, -1, 1],
-    });
-    Array.from(this.cubeAxes.getActors()).forEach(({ setVisibility }) =>
-      setVisibility(false)
-    );
-    this.cubeAxes.setCamera(this.camera);
-    this.renderer.addActor(this.cubeAxes);
+    if (this.props.showCubeAxes) {
+      this.initCubeAxes();
+    }
 
     this.subscriptions = [];
     this.subscriptions.push(
@@ -329,6 +323,18 @@ export default class View extends Component {
         }
       })
     );
+  }
+
+  initCubeAxes() {
+    this.cubeAxes = vtkCubeAxesActor.newInstance({
+      visibility: false,
+      dataBounds: [-1, 1, -1, 1, -1, 1],
+    });
+    Array.from(this.cubeAxes.getActors()).forEach(({ setVisibility }) =>
+      setVisibility(false)
+    );
+    this.cubeAxes.setCamera(this.camera);
+    this.renderer.addActor(this.cubeAxes);
   }
 
   getPointerSizeTolerance() {
@@ -386,6 +392,11 @@ export default class View extends Component {
 
   componentDidUpdate(prevProps, prevState, snapshot) {
     this.update(this.props, prevProps);
+
+    // Cube Axes
+    if (this.props.showCubeAxes && this.cubeAxes == null) {
+      this.initCubeAxes();
+    }
   }
 
   componentWillUnmount() {
@@ -467,15 +478,17 @@ export default class View extends Component {
       }
     }
 
-    if (this.cubeAxes.setVisibility(showCubeAxes)) {
-      Array.from(this.cubeAxes.getActors()).forEach(({ setVisibility }) =>
-        setVisibility(showCubeAxes)
-      );
-      this.renderView();
-    }
+    if (this.props.showCubeAxes) {
+      if (this.cubeAxes.setVisibility(showCubeAxes)) {
+        Array.from(this.cubeAxes.getActors()).forEach(({ setVisibility }) =>
+          setVisibility(showCubeAxes)
+        );
+        this.renderView();
+      }
 
-    if (this.cubeAxes.set(cubeAxesStyle || {})) {
-      this.renderView();
+      if (this.cubeAxes.set(cubeAxesStyle || {})) {
+        this.renderView();
+      }
     }
 
     if (showOrientationAxes !== this.orientationWidget.getEnabled()) {

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -392,11 +392,6 @@ export default class View extends Component {
 
   componentDidUpdate(prevProps, prevState, snapshot) {
     this.update(this.props, prevProps);
-
-    // Cube Axes
-    if (this.props.showCubeAxes && this.cubeAxes == null) {
-      this.initCubeAxes();
-    }
   }
 
   componentWillUnmount() {
@@ -479,6 +474,10 @@ export default class View extends Component {
     }
 
     if (this.props.showCubeAxes) {
+      if (this.cubeAxes == null) {
+        this.initCubeAxes();
+      }
+
       if (this.cubeAxes.setVisibility(showCubeAxes)) {
         Array.from(this.cubeAxes.getActors()).forEach(({ setVisibility }) =>
           setVisibility(showCubeAxes)

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -184,7 +184,9 @@ export default class View extends Component {
           bbox.addBounds(...prop.getBounds());
         }
       }
-      this.cubeAxes.setDataBounds(bbox.getBounds());
+      if (this.cubeAxes) {
+        this.cubeAxes.setDataBounds(bbox.getBounds());
+      }
     };
     this.debouncedCubeBounds = debounce(this.updateCubeBounds, 50);
 


### PR DESCRIPTION
We don't need to initialize cubeAxesActor if the showCubeAxes prop is false