### PR TITLE
fix(DataArray): add range info to DataArray

### DIFF
--- a/src/core/DataArray.js
+++ b/src/core/DataArray.js
@@ -59,7 +59,7 @@ export default class DataArray extends Component {
   }
 
   update(props, previous) {
-    const { name, type, values, numberOfComponents } = props;
+    const { name, type, values, numberOfComponents, range } = props;
     const klass = TYPED_ARRAYS[type];
     let changeDetected = false;
 
@@ -79,6 +79,9 @@ export default class DataArray extends Component {
 
     if (values && (changeDetected || !previous || values !== previous.values)) {
       this.array.setData(toTypedArray(values, klass), numberOfComponents);
+      if (range) {
+        this.array.setRange(range, numberOfComponents);
+      }
       changeDetected = true;
     }
 


### PR DESCRIPTION
Pass range information to DataArray externally if available, to avoid multiple calls to computeRange, since this can be a performance penalty if the image data is very large.
Example shown below:
```js
<DataArray
    registration="setScalars"
    values={dataArray}
    range={{ min: range[0], max: range[1] }}
/>
```