### PR TITLE
use Name instead of array for removal

### DIFF
--- a/src/core/DataArray.js
+++ b/src/core/DataArray.js
@@ -53,7 +53,7 @@ export default class DataArray extends Component {
   }
 
   componentWillUnmount() {
-    this.fields.removeArray(this.array);
+    this.fields.removeArray(this.array.getName(());
     this.array.delete();
     this.array = null;
   }


### PR DESCRIPTION
This fix should allow the correct unmounting of DataArrays and their removal from the fields context.

Linked to #76 