### PR TITLE
perf: don’t trigger layout event if hover is not in picking modes

### DIFF
--- a/src/core/View.js
+++ b/src/core/View.js
@@ -307,7 +307,12 @@ export default class View extends Component {
         this.getScreenEventPositionFor(e),
         e
       );
-    this.onMouseMove = (e) => this.hover(this.getScreenEventPositionFor(e), e);
+    this.onMouseMove = (e) => {
+      // Only trigger hover if it's listed in the picking modes
+      if (this.props.pickingModes.indexOf('hover') !== -1) {
+        this.hover(this.getScreenEventPositionFor(e), e);
+      }
+    };
     this.lastSelection = [];
 
     this.onBoxSelectChange = select;


### PR DESCRIPTION
This optimization avoids the need for the browser to run a Layout event in case we don't need the result of `this.getScreenEventPositionFor`.

Before this fix, we would always run the `getBoundingClientRect` and then discard its result in the `this.hover` handler.

<img width="678" alt="CleanShot 2022-10-17 at 2 55 56@2x" src="https://user-images.githubusercontent.com/5382443/196182589-b02cc021-3f43-4f4a-a43f-8ce48d108590.png">

