### PR TITLE
feat: onDataAvailable representation callback

### DIFF
--- a/src/core/Geometry2DRepresentation.tsx
+++ b/src/core/Geometry2DRepresentation.tsx
@@ -65,6 +65,16 @@ export interface Geometry2DRepresentationProps extends PropsWithChildren {
    * The coordinate system in which the input dataset resides.
    */
   transformCoordinate?: ICoordinateInitialValues;
+
+  /**
+   * Event callback for when data is made available.
+   *
+   * By the time this callback is invoked, you can be sure that:
+   * - the mapper has the input data
+   * - the actor is visible (unless explicitly marked as not visible)
+   * - initial properties are set
+   */
+  onDataAvailable?: () => void;
 }
 
 const DefaultProps = {
@@ -140,6 +150,16 @@ export default forwardRef(function Geometry2DRepresentation(
     [propertyProps],
     ([cur], [prev]) => compareShallowObject(cur, prev)
   );
+
+  // --- events --- //
+
+  const { onDataAvailable } = props;
+  useEffect(() => {
+    if (dataAvailable) {
+      // trigger onDataAvailable after making updates to the actor and mapper
+      onDataAvailable?.();
+    }
+  }, [dataAvailable, onDataAvailable]);
 
   // --- //
 

--- a/src/core/GeometryRepresentation.tsx
+++ b/src/core/GeometryRepresentation.tsx
@@ -88,6 +88,16 @@ export interface GeometryRepresentationProps extends PropsWithChildren {
    * TODO fix type
    */
   scalarBarStyle?: Record<string, unknown>;
+
+  /**
+   * Event callback for when data is made available.
+   *
+   * By the time this callback is invoked, you can be sure that:
+   * - the mapper has the input data
+   * - the actor is visible (unless explicitly marked as not visible)
+   * - initial properties are set
+   */
+  onDataAvailable?: () => void;
 }
 
 const DefaultProps = {
@@ -153,6 +163,16 @@ export default forwardRef(function GeometryRepresentation(
     [propertyProps],
     ([cur], [prev]) => compareShallowObject(cur, prev)
   );
+
+  // --- events --- //
+
+  const { onDataAvailable } = props;
+  useEffect(() => {
+    if (dataAvailable) {
+      // trigger onDataAvailable after making updates to the actor and mapper
+      onDataAvailable?.();
+    }
+  }, [dataAvailable, onDataAvailable]);
 
   // --- //
 

--- a/src/core/SliceRepresentation.tsx
+++ b/src/core/SliceRepresentation.tsx
@@ -97,6 +97,16 @@ export interface SliceRepresentationProps extends PropsWithChildren {
    * index of the slice along z
    */
   zSlice?: number;
+
+  /**
+   * Event callback for when data is made available.
+   *
+   * By the time this callback is invoked, you can be sure that:
+   * - the mapper has the input data
+   * - the actor is visible (unless explicitly marked as not visible)
+   * - initial properties are set
+   */
+  onDataAvailable?: () => void;
 }
 
 const DefaultProps = {
@@ -134,8 +144,6 @@ export default forwardRef(function SliceRepresentation(
     colorDataRange,
     trackModified
   );
-
-  // --- PWF --- //
 
   // --- mapper --- //
 
@@ -242,6 +250,16 @@ export default forwardRef(function SliceRepresentation(
       mapper.setSlice(kSlice);
     }
   }, [kSlice, getMapper, trackModified]);
+
+  // --- events --- //
+
+  const { onDataAvailable } = props;
+  useEffect(() => {
+    if (dataAvailable) {
+      // trigger onDataAvailable after making updates to the actor and mapper
+      onDataAvailable?.();
+    }
+  }, [dataAvailable, onDataAvailable]);
 
   // --- //
 


### PR DESCRIPTION
This adds an onDataAvailable callback to the Representation components. This gives users the ability to know when the data has been added to the scene, enabling functionality such as resetting the camera once the data has been added.