### PR TITLE
fix: removing datasets doesn't inform the representation

### DIFF
--- a/src/core/Algorithm.tsx
+++ b/src/core/Algorithm.tsx
@@ -100,6 +100,7 @@ export default function Algorithm(props: AlgorithmProps) {
 
   useUnmount(() => {
     if (algoRef.current) {
+      representation.dataAvailable(false);
       deletionRegistry.markForDeletion(algoRef.current);
       algoRef.current = null;
     }

--- a/src/core/Dataset.tsx
+++ b/src/core/Dataset.tsx
@@ -14,11 +14,12 @@ export default function Dataset(props: DatasetProps) {
 
   useEffect(() => {
     if (!dataset) {
+      representation.dataAvailable(false);
       return;
     }
 
     downstream.setInputData(dataset);
-    representation.dataAvailable();
+    representation.dataAvailable(true);
     representation.dataChanged();
   }, [dataset, downstream, representation]);
 

--- a/src/core/Geometry2DRepresentation.tsx
+++ b/src/core/Geometry2DRepresentation.tsx
@@ -177,8 +177,8 @@ export default forwardRef(function Geometry2DRepresentation(
       dataChanged: () => {
         renderer.requestRender();
       },
-      dataAvailable: () => {
-        setDataAvailable(true);
+      dataAvailable: (available = true) => {
+        setDataAvailable(available);
         representation.dataChanged();
       },
       getActor,

--- a/src/core/ImageData.tsx
+++ b/src/core/ImageData.tsx
@@ -98,6 +98,7 @@ export default forwardRef(function PolyData(props: ImageDataProps, fwdRef) {
 
   useUnmount(() => {
     if (imRef.current) {
+      representation.dataAvailable(false);
       deletionRegistry.markForDeletion(imRef.current);
       imRef.current = null;
     }

--- a/src/core/PolyData.tsx
+++ b/src/core/PolyData.tsx
@@ -220,6 +220,7 @@ export default forwardRef(function PolyData(props: PolyDataProps, fwdRef) {
 
   useUnmount(() => {
     if (pdRef.current) {
+      representation.dataAvailable(false);
       deletionRegistry.markForDeletion(pdRef.current);
       pdRef.current = null;
     }

--- a/src/core/Reader.tsx
+++ b/src/core/Reader.tsx
@@ -89,9 +89,10 @@ export default function Reader(props: ReaderProps) {
     deletionRegistry.register(reader, () => reader.delete());
     readerRef.current = reader;
     return () => {
+      representation.dataAvailable(false);
       deletionRegistry.markForDeletion(reader);
     };
-  }, [createReader]);
+  }, [createReader, representation]);
 
   // --- url handling --- //
 

--- a/src/core/ShareDataSet.tsx
+++ b/src/core/ShareDataSet.tsx
@@ -205,7 +205,7 @@ export function UseDataSet(props: UseDataSetProps) {
   useEffect(() => {
     return share.onDataAvailable(id, (ds) => {
       downstream.setInputData(ds as vtkObject, port);
-      representation.dataAvailable();
+      representation.dataAvailable(!!ds);
     });
   }, [id, port, representation, downstream, share]);
 

--- a/src/core/SliceRepresentation.tsx
+++ b/src/core/SliceRepresentation.tsx
@@ -277,8 +277,8 @@ export default forwardRef(function SliceRepresentation(
       dataChanged: () => {
         renderer.requestRender();
       },
-      dataAvailable: () => {
-        setDataAvailable(true);
+      dataAvailable: (available = true) => {
+        setDataAvailable(available);
         representation.dataChanged();
       },
       getActor,

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface IView {
 }
 
 export interface IRepresentation {
-  dataAvailable(): void;
+  dataAvailable(available?: boolean): void;
   dataChanged(): void;
   getActor(): vtkProp | null;
   getMapper(): vtkAbstractMapper | null;

--- a/usage/src/App.jsx
+++ b/usage/src/App.jsx
@@ -40,6 +40,7 @@ const demos = new Map([
     'Tests/SimpleSliceRendering',
     lazy(() => import('./Tests/SimpleSliceRendering')),
   ],
+  ['Tests/RemoveImageData', lazy(() => import('./Tests/RemoveImageData'))],
   [
     'Tests/ChangeInteractorStyle',
     lazy(() => import('./Tests/ChangeInteractorStyle')),

--- a/usage/src/Tests/RemoveImageData.jsx
+++ b/usage/src/Tests/RemoveImageData.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import {
+  DataArray,
+  ImageData,
+  PointData,
+  SliceRepresentation,
+  View,
+} from 'react-vtk-js';
+
+function generateRandomVolumeField(iMax, jMax, kMax) {
+  const array = [];
+  for (let k = 0; k < kMax; k++) {
+    for (let j = 0; j < jMax; j++) {
+      for (let i = 0; i < iMax; i++) {
+        array.push(Math.random());
+      }
+    }
+  }
+  return array;
+}
+
+const VALUES = generateRandomVolumeField(10, 10, 10);
+
+function Example() {
+  const [showImage, setShowImage] = useState(true);
+
+  const removeImage = () => {
+    setShowImage(false);
+  };
+
+  const im = showImage ? (
+    <ImageData spacing={[1, 1, 1]} dimensions={[10, 10, 10]} origin={[0, 0, 0]}>
+      <PointData>
+        <DataArray
+          registration='setScalars'
+          type='Float32Array'
+          values={VALUES}
+        />
+      </PointData>
+    </ImageData>
+  ) : null;
+
+  return (
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <View>
+        <SliceRepresentation
+          iSlice={8}
+          property={{ colorWindow: 1, colorLevel: 0.5 }}
+        >
+          {im}
+        </SliceRepresentation>
+      </View>
+      <div style={{ position: 'absolute', top: 0 }}>
+        <button onClick={removeImage}>Remove Image</button>
+      </div>
+    </div>
+  );
+}
+
+export default Example;


### PR DESCRIPTION
Removing the dataset component (e.g. `ImageData`) but not the containing representation results in bad behavior, since the dataset is deleted but a reference is still used by the representation's mapper.

This change introduces an optional flag parameter to `representation.dataAvailable(available?)`. When false, the representation will hide the actor, as the input data is no longer considered available.