### PR TITLE
Fix setRange call to vtkDataArray for single component arrays

### DIFF
--- a/src/core/DataArray.ts
+++ b/src/core/DataArray.ts
@@ -110,7 +110,11 @@ export default function DataArray(props: DataArrayProps) {
       const typedArrayClass = TypedArrayLookup[TYPED_ARRAYS[type]];
       array.setData(toTypedArray(values, typedArrayClass), numberOfComponents);
       if (range) {
-        array.setRange(range, numberOfComponents);
+        if (numberOfComponents === 1) {
+          array.setRange(range, 0);
+        } else {
+          array.setRange(range, numberOfComponents);
+        }
       }
     }
 


### PR DESCRIPTION
Fix setRange call to vtkDataArray for single component arrays.

There may be cases ([such as here](https://github.com/Kitware/vtk-js/blob/e765741ee8a0276aa6a24578a294ffd83a77a719/Sources/Common/Core/Points/index.js#L39)) where an explicit call is made to `vtkDataArray::getRange(range, 0)` with index === 0. This can trigger unexpected call to computeRange if setRange isn't called with index === 0 before.