### PR TITLE
fix(ParentedView): switch interactor on capture

### DIFF
--- a/src/core/internal/ParentedView.tsx
+++ b/src/core/internal/ParentedView.tsx
@@ -91,11 +91,9 @@ const ParentedView = forwardRef(function ParentedView(
     const rendererAPI = rendererRef.current;
     if (!rendererAPI) return false;
 
-    const interactor = getInteractor();
+    const interactor = getInteractor() as FixedVTKRenderWindowInteractor;
 
-    (interactor as FixedVTKRenderWindowInteractor).setCurrentRenderer(
-      rendererAPI.get()
-    );
+    interactor.setCurrentRenderer(rendererAPI.get());
     interactor.setInteractorStyle(getInteractorStyle());
 
     const oldContainer = interactor.getContainer();
@@ -108,21 +106,23 @@ const ParentedView = forwardRef(function ParentedView(
 
   // Use wheel events to cover the posibility of interacting
   // with an out-of-focus browser window.
-  useEventListener(containerRef, 'wheel', (ev: WheelEvent) => {
-    if (switchTarget()) {
-      // forward wheel-event to interactor
-      const interactor = getInteractor();
-      interactor.handleWheel(ev);
-    }
-  });
+  useEventListener(
+    containerRef,
+    'wheel',
+    () => {
+      switchTarget();
+    },
+    { capture: true }
+  );
 
-  useEventListener(containerRef, 'pointerenter', (ev: PointerEvent) => {
-    if (switchTarget()) {
-      // forward pointer-event to interactor
-      const interactor = getInteractor();
-      interactor.handlePointerEnter(ev);
-    }
-  });
+  useEventListener(
+    containerRef,
+    'pointerenter',
+    () => {
+      switchTarget();
+    },
+    { capture: true }
+  );
 
   // --- resize handling --- //
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,6 +6,7 @@ declare module '@kitware/vtk.js/type-patches' {
   export interface FixedVTKRenderWindowInteractor
     extends vtkRenderWindowInteractor {
     setCurrentRenderer(ren: vtkRenderer): void;
+    setContainer(el: HTMLElement | null): boolean;
   }
 
   export interface VtkRendererEvent {


### PR DESCRIPTION
Before, the call to `switchTarget()` would happen _after_ the interactor has already handled the event. This can cause issues with the initial interaction event target being incorrect.

This change moves the call to the capture phase, so that the interactor will be properly switched before vtk.js processes any events.

FYI @jadh4v this should address the out-of-focus wheel event issue without changing the vtkInteractorStyleManipulator.