### PR TITLE
fix(Picking): guard against unmounted state

### DIFF
--- a/src/core/Picking.ts
+++ b/src/core/Picking.ts
@@ -163,6 +163,8 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
       const y2 = Math.ceil(yp + tolerance);
 
       const selector = getSelector();
+      if (selector.isDeleted()) return [];
+
       const openGLRenderWindow = openGLRenderWindowAPI.get();
       const renderer = rendererAPI.get();
 
@@ -231,6 +233,8 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
       if (!isMounted.current) return [];
 
       const selector = getSelector();
+      if (selector.isDeleted()) return [];
+
       const openGLRenderWindow = openGLRenderWindowAPI.get();
       const renderer = rendererAPI.get();
 
@@ -297,6 +301,8 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
       if (!isMounted.current) return null;
 
       const selector = getSelector();
+      if (selector.isDeleted()) return null;
+
       const openGLRenderWindow = openGLRenderWindowAPI.get();
       const renderer = rendererAPI.get();
 

--- a/src/core/Picking.ts
+++ b/src/core/Picking.ts
@@ -13,6 +13,7 @@ import {
 import deletionRegistry from '../utils/DeletionRegistry';
 import useDebounce from '../utils/useDebounce';
 import useGetterRef from '../utils/useGetterRef';
+import { useIsMounted } from '../utils/useIsMounted';
 import useMount from '../utils/useMount';
 import useUnmount from '../utils/useUnmount';
 import {
@@ -136,6 +137,8 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
     };
   });
 
+  const isMounted = useIsMounted();
+
   // --- Props --- //
 
   const {
@@ -152,6 +155,8 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
 
   const pickClosest = useCallback(
     (xp: number, yp: number, tolerance: number): PickResult[] => {
+      if (!isMounted.current) return [];
+
       const x1 = Math.floor(xp - tolerance);
       const y1 = Math.floor(yp - tolerance);
       const x2 = Math.ceil(xp + tolerance);
@@ -218,11 +223,13 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
         },
       ] as PickResult[];
     },
-    [rendererAPI, openGLRenderWindowAPI, getSelector]
+    [rendererAPI, openGLRenderWindowAPI, isMounted, getSelector]
   );
 
   const pick = useCallback(
     (x1: number, y1: number, x2: number, y2: number): PickResult[] => {
+      if (!isMounted.current) return [];
+
       const selector = getSelector();
       const openGLRenderWindow = openGLRenderWindowAPI.get();
       const renderer = rendererAPI.get();
@@ -277,7 +284,7 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
         })
         .filter(Boolean) as PickResult[];
     },
-    [rendererAPI, openGLRenderWindowAPI, getSelector]
+    [rendererAPI, openGLRenderWindowAPI, isMounted, getSelector]
   );
 
   const pickWithFrustum = useCallback(
@@ -287,6 +294,8 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
       x2: number,
       y2: number
     ): FrustumPickResult | null => {
+      if (!isMounted.current) return null;
+
       const selector = getSelector();
       const openGLRenderWindow = openGLRenderWindowAPI.get();
       const renderer = rendererAPI.get();
@@ -324,7 +333,7 @@ export default forwardRef(function ViewPicking(props: PickingProps, fwdRef) {
       });
       return { frustum, representationIds };
     },
-    [rendererAPI, openGLRenderWindowAPI, getSelector]
+    [rendererAPI, openGLRenderWindowAPI, isMounted, getSelector]
   );
 
   const api = useMemo(

--- a/src/utils/useIsMounted.ts
+++ b/src/utils/useIsMounted.ts
@@ -1,0 +1,17 @@
+import { useRef } from 'react';
+import useMount from './useMount';
+import useUnmount from './useUnmount';
+
+export function useIsMounted() {
+  const isMounted = useRef(false);
+
+  useMount(() => {
+    isMounted.current = true;
+  });
+
+  useUnmount(() => {
+    isMounted.current = false;
+  });
+
+  return isMounted;
+}


### PR DESCRIPTION
It's possible for picking to occur after the component is unmounted. Add guards for this.