### PR TITLE
Fix crash on style.delete()

### DIFF
--- a/src/core/View.js
+++ b/src/core/View.js
@@ -427,10 +427,12 @@ export default class View extends Component {
       this.interactor.setInteractorStyle(null);
     }
 
-    this.style.delete();
+    if (this.style) {
+      this.style.delete();
+      this.style = null;
+    }
     this.defaultStyle.delete();
     this.defaultStyle = null;
-    this.style = null;
     this.renderer = null;
     this.selector = null;
     this.orientationWidget = null;


### PR DESCRIPTION
When `interactive` prop is set to `false`, `this.style` remains null, but component's `componentWillUnmount` method still tries to delete it and crash.