### PR TITLE
🔧 MA-34 Fix Reader TSX

### DIFF
--- a/src/core/Reader.tsx
+++ b/src/core/Reader.tsx
@@ -147,4 +147,6 @@ export default function Reader(props: ReaderProps) {
 
     downstream.setInputConnection(reader.getOutputPort(), port);
   });
+
+  return <></>;
 }


### PR DESCRIPTION
## What

- Bugfix (Non-breaking change that solves an issue)

## Why

![Screenshot 2024-06-19 at 13 39 46](https://github.com/Kitware/react-vtk-js/assets/69109201/5e748d4a-ec6f-4c3d-8d09-1d86f422ee65)

When you use `Reader.tsx` in a `tsx` file, it might throw an error.

## How

Don't worry, it's an easy fix!

Just add a `return` statement to `Reader.tsx`, and return an empty HTML tag, like this: `<></>`

That should do the trick! Let me know if you need anything else.

## How to Test

Just use `Reader` in a `TSX` file and you won't have any errors.

Like this:

```typescript
<VolumeRepresentation>
    <VolumeController />
    <Reader vtkClass={vtkXMLImageDataReader} url={url} />
</VolumeRepresentation>
```

## Additional Remarks

No.

Just give us a shout if you got any questions, no worries.
