### PR TITLE
Support user defined color map preset

### DIFF
--- a/src/core/Geometry2DRepresentation.tsx
+++ b/src/core/Geometry2DRepresentation.tsx
@@ -2,6 +2,7 @@ import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import vtkActor2D, {
   IActor2DInitialValues,
 } from '@kitware/vtk.js/Rendering/Core/Actor2D';
+import { IColorMapPreset } from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import { ICoordinateInitialValues } from '@kitware/vtk.js/Rendering/Core/Coordinate';
 import { Coordinate } from '@kitware/vtk.js/Rendering/Core/Coordinate/Constants';
 import vtkMapper2D, {
@@ -55,9 +56,9 @@ export interface Geometry2DRepresentationProps extends PropsWithChildren {
   property?: IProperty2DInitialValues;
 
   /**
-   * Preset name for the lookup table color map
+   * Preset name for the lookup table color map or user provided color map preset
    */
-  colorMapPreset?: string;
+  colorMapPreset?: string | IColorMapPreset;
 
   /**
    * Data range use for the colorMap

--- a/src/core/GeometryRepresentation.tsx
+++ b/src/core/GeometryRepresentation.tsx
@@ -2,6 +2,7 @@ import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import vtkActor, {
   IActorInitialValues,
 } from '@kitware/vtk.js/Rendering/Core/Actor';
+import { IColorMapPreset } from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import vtkMapper, {
   IMapperInitialValues,
 } from '@kitware/vtk.js/Rendering/Core/Mapper';
@@ -52,9 +53,9 @@ export interface GeometryRepresentationProps extends PropsWithChildren {
   property?: IPropertyInitialValues;
 
   /**
-   * Preset name for the lookup table color map
+   * Preset name for the lookup table color map or user provided color map preset
    */
-  colorMapPreset?: string;
+  colorMapPreset?: string | IColorMapPreset;
 
   /**
    * Data range use for the colorMap

--- a/src/core/SliceRepresentation.tsx
+++ b/src/core/SliceRepresentation.tsx
@@ -4,6 +4,7 @@ import AbstractImageMapper, {
   vtkAbstractImageMapper,
 } from '@kitware/vtk.js/Rendering/Core/AbstractImageMapper';
 import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
+import { IColorMapPreset } from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import vtkImageArrayMapper from '@kitware/vtk.js/Rendering/Core/ImageArrayMapper';
 import vtkImageMapper, {
   IImageMapperInitialValues,
@@ -64,9 +65,9 @@ export interface SliceRepresentationProps extends PropsWithChildren {
   property?: IImagePropertyInitialValues;
 
   /**
-   * Preset name for the lookup table color map
+   * Preset name for the lookup table color map or user provided color map preset
    */
-  colorMapPreset?: string;
+  colorMapPreset?: string | IColorMapPreset;
 
   /**
    * Data range use for the colorMap

--- a/src/core/VolumeRepresentation.tsx
+++ b/src/core/VolumeRepresentation.tsx
@@ -2,6 +2,7 @@ import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
 import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkPiecewiseFunction from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
 import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
+import { IColorMapPreset } from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import vtkVolume, {
   IVolumeInitialValues,
 } from '@kitware/vtk.js/Rendering/Core/Volume';
@@ -63,9 +64,9 @@ export interface VolumeRepresentationProps extends PropsWithChildren {
   property?: IVolumePropertyInitialValues;
 
   /**
-   * Preset name for the lookup table color map
+   * Preset name for the lookup table color map or user provided color map preset
    */
-  colorMapPreset?: string;
+  colorMapPreset?: string | IColorMapPreset;
 
   /**
    * Data range use for the colorMap

--- a/src/core/modules/useColorTransferFunction.ts
+++ b/src/core/modules/useColorTransferFunction.ts
@@ -1,5 +1,7 @@
 import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
-import vtkColorMaps from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
+import vtkColorMaps, {
+  IColorMapPreset,
+} from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import { Vector2 } from '@kitware/vtk.js/types';
 import { compareVector2 } from '../../utils/comparators';
 import deletionRegistry from '../../utils/DeletionRegistry';
@@ -9,7 +11,7 @@ import useGetterRef from '../../utils/useGetterRef';
 import useUnmount from '../../utils/useUnmount';
 
 export default function useColorTransferFunction(
-  presetName: string,
+  colorMapPreset: string | IColorMapPreset,
   range: Vector2,
   trackModified: BooleanAccumulator
 ) {
@@ -19,11 +21,18 @@ export default function useColorTransferFunction(
     return func;
   });
 
+  const isPassedInPresetName = typeof colorMapPreset === 'string';
+  const presetName = isPassedInPresetName
+    ? colorMapPreset
+    : colorMapPreset.Name;
+
   useComparableEffect(
     () => {
       if (!presetName || !range) return;
       const lut = getLUT();
-      const preset = vtkColorMaps.getPresetByName(presetName);
+      const preset = isPassedInPresetName
+        ? vtkColorMaps.getPresetByName(presetName)
+        : colorMapPreset;
       lut.applyColorMap(preset);
       lut.setMappingRange(range[0], range[1]);
       lut.updateRange();


### PR DESCRIPTION
Context:
Add user defined color map preset

Result:
Users will be able to pass in customized colormap preset with colorMapPreset prop in related representation components.
