### PR TITLE
fix(ParentedView): mark wheel event listener as passive

### DIFF
--- a/src/core/internal/ParentedView.tsx
+++ b/src/core/internal/ParentedView.tsx
@@ -113,7 +113,7 @@ const ParentedView = forwardRef(function ParentedView(
     () => {
       switchTarget();
     },
-    { capture: true }
+    { capture: true, passive: true }
   );
 
   useEventListener(


### PR DESCRIPTION
## Problem

The `wheel` event listener in `ParentedView` is registered with `{ capture: true }` but without `passive: true`. This triggers a browser violation warning:

> [Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.

## Fix

Add `passive: true` to the wheel event listener options:

```ts
useEventListener(
  containerRef,
  'wheel',
  () => { switchTarget(); },
  { capture: true, passive: true }  // was: { capture: true }
);
```

The handler only calls `switchTarget()` and never calls `preventDefault()`, so marking it passive is safe and removes the browser warning.